### PR TITLE
fix-example-with-new-env-set

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
     - uses: actions/checkout@v1
     - run: echo "${{ github.event.head_commit.message }}" | tr '\n' ' '
     - name: get commit message
-      run: echo ::set-env name=COMMIT_MESSAGE::$(echo "${{ github.event.head_commit.message }}" | tr '\n' ' ')
+      run: echo "COMMIT_MESSAGE=${{ github.event.head_commit.message }}" | tr '\n' ' ' >> $GITHUB_ENV
     - name: post a message to slack
       uses: ./
       env:

--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ Here's what the Slack message would look like:
 
 ```yaml
 - name: Set COMMIT_MESSAGE
-  run: echo ::set-env name=COMMIT_MESSAGE::$(echo "${{ github.event.head_commit.message }}" | tr '\n' ' ')
+    run: |
+      echo "COMMIT_MESSAGE=${{ github.event.head_commit.message }}" | tr '\n' ' ' >> $GITHUB_ENV
 - name: Slack Notification on SUCCESS
   if: success()
   uses: tokorom/action-slack-incoming-webhook@main

--- a/README.md
+++ b/README.md
@@ -35,8 +35,7 @@ Here's what the Slack message would look like:
 
 ```yaml
 - name: Set COMMIT_MESSAGE
-    run: |
-      echo "COMMIT_MESSAGE=${{ github.event.head_commit.message }}" | tr '\n' ' ' >> $GITHUB_ENV
+    run: echo "COMMIT_MESSAGE=${{ github.event.head_commit.message }}" | tr '\n' ' ' >> $GITHUB_ENV
 - name: Slack Notification on SUCCESS
   if: success()
   uses: tokorom/action-slack-incoming-webhook@main


### PR DESCRIPTION
set-env has been deprecated and can no longer be used.

This updated example uses github's recommended Environmentfile set

https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#environment-files
