### PR TITLE
docs: add Block Kit Builder URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
     - Don't use legacy incoming Webhooks on custom integrations
 - You can use the names of the fields in the Message payloads provided by Slack
     - https://api.slack.com/reference/messaging/payload
+    - https://app.slack.com/block-kit-builder (Sign in needed)
 
 ## Simple Usage
 


### PR DESCRIPTION
To make the slack message easier, Add Block Kit Builder URL from Slack Docs.