### PR TITLE
feat: improve error handling and logging

### DIFF
--- a/lib/sendMessage.js
+++ b/lib/sendMessage.js
@@ -1,24 +1,37 @@
 const core = require('@actions/core')
 const fetch = require('node-fetch')
 
+class HTTPResponseError extends Error {
+  constructor(response) {
+    super(`HTTP Error Response: ${response.status} ${response.statusText}`);
+    this.response = response;
+  }
+}
+
+function checkStatus(response) {
+  if (response.ok) {
+    return response;
+  } else {
+    throw new HTTPResponseError(response);
+  }
+}
+
 async function sendMessage(message, to) {
-  try { 
-    const res = await fetch(to, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json; charset=utf-8',
-      },
-      body: JSON.stringify(message)
-    })
+  const response = await fetch(to, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json; charset=utf-8",
+    },
+    body: JSON.stringify(message),
+  });
 
-    if (!res.ok) {
-      throw new Error(`Request failed with status ${res.status}`)
-    }
-
-    return await res.statusText
-  } 
-  catch (error) {
-    throw error
+  try {
+    const validResponse = checkStatus(response);
+    return validResponse.statusText;
+  } catch (error) {
+    const errorBody = await error.response.text();
+    core.error(`Error body: ${errorBody}`);
+    throw error;
   }
 }
 


### PR DESCRIPTION
Small PR to print the slack response body in case of an error which can be useful for debugging.
See the list of errors here: https://api.slack.com/messaging/webhooks#handling_errors

I used the example from the `node-fetch` lib for the implementation:
https://github.com/node-fetch/node-fetch?tab=readme-ov-file#handling-client-and-server-errors

Here's what it looks like when you have an error
<img width="400" alt="image" src="https://github.com/user-attachments/assets/65ffc559-1aab-476e-955e-0ad0202a8d04">